### PR TITLE
openst: fix error 409 multiple networks

### DIFF
--- a/jcs/openst.py
+++ b/jcs/openst.py
@@ -36,12 +36,12 @@ class OpenstClient:
         if not instance_type:
             raise Exception('OS instance type (flavor) "{}" not found'.format(instance_type))
 
-        network_fixed = self._conn.get_network(network_fixed)
+        network_fixed = self._conn.get_network(network_fixed) or network_public
 
         # create instance
         instance = self._conn.create_server(
             instance_name, image=image, flavor=instance_type, key_name=key_name,
-            network=network_public, security_groups=security_groups,
+            network=network_fixed, security_groups=security_groups,
             wait=True, auto_ip=True)
 
         # add floating ip

--- a/jcs/openst.py
+++ b/jcs/openst.py
@@ -41,7 +41,7 @@ class OpenstClient:
         # create instance
         instance = self._conn.create_server(
             instance_name, image=image, flavor=instance_type, key_name=key_name,
-            network=network_fixed, security_groups=security_groups,
+            network=network_public, security_groups=security_groups,
             wait=True, auto_ip=True)
 
         # add floating ip


### PR DESCRIPTION
Specify public network.

This fixes the error 409 "multiple possible networks":
```
    + jcs --os-network-public Ext-Net create --cloud openstack --instance-type s1-8 --jenkins-credential storage-automation-for-root-user minimal-opensuse-15.4-x86_64 sesdev-integration_master-19
    Connected to jenkins server 2.378
    Traceback (most recent call last):
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/bin/jcs", line 8, in <module>
        sys.exit(main())
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/jcs/__init__.py", line 289, in main
        args.func(args)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/jcs/__init__.py", line 189, in _do_create
        args.os_network_fixed, args.os_network_public, args.os_security_groups)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/jcs/openst.py", line 45, in os_instance_create
        wait=True, auto_ip=True)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/decorator.py", line 232, in fun
        return caller(func, *(extras + args), **kw)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/cloud/_utils.py", line 235, in func_wrapper
        return func(*args, **kwargs)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/cloud/_compute.py", line 922, in create_server
        server = self.compute.create_server(**kwargs)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/compute/v2/_proxy.py", line 652, in create_server
        return self._create(_server.Server, **attrs)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/proxy.py", line 581, in _create
        return res.create(self, base_path=base_path)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/resource.py", line 1487, in create
        self._translate_response(response, has_body=has_body)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/resource.py", line 1254, in _translate_response
        exceptions.raise_from_response(response, error_message=error_message)
      File "/tmp/ws/sesdev-integration/master/19/jcs/venv/lib/python3.6/site-packages/openstack/exceptions.py", line 235, in raise_from_response
        http_status=http_status, request_id=request_id
    openstack.exceptions.ConflictException: ConflictException: 409: Client Error for url: https://compute.de1.cloud.ovh.net/v2.1/68bb3d2bb759469c94d53c072b024f22/servers, Multiple possible networks found, use a Network ID to be more specific.
    script returned exit code 1
```

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>